### PR TITLE
feat(ab): add A/B trial cookie and /trial page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { assignTrialIfMissing } from './src/lib/ab';
+
+export function middleware(request: NextRequest) {
+  // APIルートは除外
+  if (request.nextUrl.pathname.startsWith('/api')) {
+    return NextResponse.next();
+  }
+  
+  const response = NextResponse.next();
+  return assignTrialIfMissing(request, response);
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+  ],
+};

--- a/src/app/trial/page.tsx
+++ b/src/app/trial/page.tsx
@@ -1,0 +1,21 @@
+import { cookies } from 'next/headers';
+import { getTrialBucketFromCookies } from '@/lib/ab';
+
+export default function TrialPage() {
+  const cookieStore = cookies();
+  const bucket = getTrialBucketFromCookies(cookieStore);
+  
+  return (
+    <div className="container mx-auto p-8">
+      <h1 className="text-3xl font-bold mb-4">A/B Trial Test</h1>
+      <div className="bg-gray-100 p-4 rounded-lg">
+        <p className="text-xl">
+          You are in bucket: <strong className="text-blue-600">{bucket}</strong>
+        </p>
+        <p className="text-sm text-gray-600 mt-2">
+          このバケット情報は1年間Cookieに保存されます
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/ab.ts
+++ b/src/lib/ab.ts
@@ -1,0 +1,37 @@
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+
+export type TrialBucket = 'A' | 'B';
+
+export function getTrialBucketFromCookies(cookieStore: any): TrialBucket {
+  const trialCookie = cookieStore.get('kc_trial');
+  const bucket = trialCookie?.value;
+  
+  if (bucket === 'A' || bucket === 'B') {
+    return bucket;
+  }
+  
+  // デフォルトはA（通常はmiddlewareで設定されるため、ここは到達しない想定）
+  return 'A';
+}
+
+export function assignTrialIfMissing(
+  req: NextRequest, 
+  res: NextResponse
+): NextResponse {
+  const existingTrial = req.cookies.get('kc_trial');
+  
+  if (!existingTrial) {
+    // 50/50でA/Bを振り分け
+    const bucket: TrialBucket = Math.random() < 0.5 ? 'A' : 'B';
+    
+    res.cookies.set('kc_trial', bucket, {
+      maxAge: 31536000, // 1年 (365日 * 24時間 * 3600秒)
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      httpOnly: false // フロントエンドからも読み取り可能
+    });
+  }
+  
+  return res;
+}


### PR DESCRIPTION
初回訪問時に kc_trial=A|B を付与。/trial で確認用ページを追加。